### PR TITLE
security among microservice 2

### DIFF
--- a/profile-service/src/main/java/com/devteria/profile/configuration/SecurityConfig.java
+++ b/profile-service/src/main/java/com/devteria/profile/configuration/SecurityConfig.java
@@ -19,7 +19,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     private static final String[] PUBLIC_ENDPOINTS = {
-
+        "/internal/users"
     };
 
     private final CustomJwtDecoder customJwtDecoder;


### PR DESCRIPTION
1. public endpoint `createProfile` để  microservice khác request tới mà không cần phải token
**2. Tóm tắt:** authentication ở api gateway, authorization ở các service why? => authentication phải tập trung, ở api gateway để chỉ có điểm đầu vào duy nhất dễ quản lý và nguy cơ về ris cũng thấp hơn. Còn lại, service tự quyết định authorization  cho chính mk, tạo sự linh hoạt, 1 điểm nữa là apigateway dùng chung cho all service nên nếu để authorization ở api gateway sẽ khó maintain. => service nào làm nghiệp vụ nào thì nó tự quyết định cái authorization của chính nó.